### PR TITLE
Correct UTM tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # OI test 
 
-<a href="https://console.platform.sh/projects/create-project/?template=https://github.com/nvelychenko/openideal-composer/blob/3.x-dev/template-definition.yaml&utm_campaign=deploy_on_platform?utm_medium=button&utm_source=affiliate_links&utm_content=https://github.com/nvelychenko/openideal-composer/blob/3.x-dev/template-definition.yaml" target="_blank" title="Deploy with Platform.sh"><img src="https://platform.sh/images/deploy/deploy-button-lg-blue.svg"></a>
+<a href="https://console.platform.sh/projects/create-project/?template=https://github.com/nvelychenko/openideal-composer/blob/3.x-dev/template-definition.yaml&utm_campaign=deploy_on_platform?utm_medium=button&utm_source=affiliate_links&utm_content=openideal_composer" target="_blank" title="Deploy with Platform.sh"><img src="https://platform.sh/images/deploy/deploy-button-lg-blue.svg"></a>


### PR DESCRIPTION
It's great to see the Deploy on Platform.sh button here!  The utm_content should be a simple machine name, though.  It's just for our tracking, and doesn't impact the template that is used.